### PR TITLE
feat: Establish project setup and documentation

### DIFF
--- a/GeminiAppCanvasCLI.jsx
+++ b/GeminiAppCanvasCLI.jsx
@@ -1,16 +1,16 @@
-import React, { useState, useEffect, useRef } from 'react';
+// React is loaded globally from the CDN, so no import is needed.
 
 // Main App Component
-export default function App() {
-  const [history, setHistory] = useState([
+function App() {
+  const [history, setHistory] = React.useState([
     {
       command: 'welcome',
       output: 'CLI restored. All tools, including the advanced `probe` and deep `fibertree` commands, are now fully functional.',
     },
   ]);
-  const [command, setCommand] = useState('');
-  const terminalRef = useRef(null);
-  const appRootRef = useRef(null);
+  const [command, setCommand] = React.useState('');
+  const terminalRef = React.useRef(null);
+  const appRootRef = React.useRef(null);
 
   // --- Start of Advanced Probe Helpers ---
   const runTest = async (title, testFn) => {
@@ -267,7 +267,7 @@ export default function App() {
     if (e.key === 'Enter') { e.preventDefault(); processCommand(command); setCommand(''); }
   };
   
-  useEffect(() => { terminalRef.current?.scrollTo(0, terminalRef.current.scrollHeight); }, [history]);
+  React.useEffect(() => { terminalRef.current?.scrollTo(0, terminalRef.current.scrollHeight); }, [history]);
 
   return (
     <div ref={appRootRef} className="bg-black text-white font-mono h-screen p-4 flex flex-col">
@@ -302,3 +302,9 @@ export default function App() {
     </div>
   );
 }
+
+// --- Self-Rendering Logic ---
+// This code will be executed after the App function is defined.
+const container = document.getElementById('root');
+const root = ReactDOM.createRoot(container);
+root.render(React.createElement(App));

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,51 @@
+# Project Setup and Configuration
+
+## Overview
+
+This project consists of a collection of standalone React components designed to run in a specific, sandboxed "Canvas" environment. They are not part of a traditional Node.js/npm project. Instead of a build step, all dependencies, including React itself, are expected to be loaded at runtime, typically from a Content Delivery Network (CDN).
+
+The components are highly specialized tools for environment introspection, security testing, and advanced agent-based interactions.
+
+## Core Requirements
+
+### 1. Execution Environment
+
+- **Host HTML File:** A parent `index.html` file is required to host the components.
+- **React & ReactDOM:** These libraries must be loaded globally, usually via `<script>` tags from a CDN, before any component scripts are executed.
+- **Root Element:** The host HTML file must contain a root DOM element (e.g., `<div id="root"></div>`) where the React component will be mounted.
+
+### 2. Dependencies
+
+The components rely on several external libraries being available in the global scope. These should be included in the host HTML file.
+
+- **React:** `https://unpkg.com/react@18/umd/react.development.js`
+- **ReactDOM:** `https://unpkg.com/react-dom@18/umd/react-dom.development.js`
+- **Babel (for JSX):** `https://unpkg.com/@babel/standalone/babel.min.js` (Required to transpile JSX in the browser)
+
+**Component-Specific Dependencies:**
+
+- **`GeminiAppJavascriptIntrospector.jsx`**:
+  - `acorn`: `https://unpkg.com/acorn/dist/acorn.js`
+  - `estraverse`: `https://unpkg.com/estraverse/estraverse.js`
+
+- **`GeminiCDNCanary.txt` / `GeminiAppProbeReactApp.txt`**: These components dynamically load various other libraries (e.g., Firebase, JSON5, Peggy.js) as part of their testing function. The host environment must allow script injection and cross-origin requests (or use a proxy like `api.allorigins.win`).
+
+### 3. Configuration (Global Variables)
+
+Several components expect global JavaScript variables to be defined in the `window` scope by the host environment. These are used for backend integration and authentication.
+
+- **`__firebase_config`**: (String or Object) A Firebase configuration object.
+- **`__app_id`**: (String) A unique identifier for the application instance.
+- **`__initial_auth_token`**: (String) A JWT token for initial Firebase authentication.
+- **`GEMINI_API_KEY`**: (String) An API key for the Google Gemini API. This is found as a placeholder in `GeminiAppCanvasAgent.txt` and `GeminiAppProbeReactApp.txt`.
+
+### 4. Running a Component (Example)
+
+To run a component, you must:
+
+1.  Rename the component file from `.txt` or `.jsx` to a consistent `.jsx` extension.
+2.  In the host HTML file, add a `<script type="text/babel">` tag that:
+    -   Imports the component.
+    -   Uses `ReactDOM.createRoot()` and `root.render()` to mount the component into the designated root element.
+
+This setup provides the necessary framework to run and test each of the provided standalone tools.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>React Component Runner</title>
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background-color: #000;
+      color: #fff;
+      font-family: sans-serif;
+    }
+    #root {
+      height: 100%;
+    }
+  </style>
+  <!-- 1. Load React, ReactDOM, and Babel -->
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <!-- 2. Define global configuration variables (as placeholders) -->
+  <script>
+    // These are placeholders. The actual environment would provide these.
+    window.__firebase_config = JSON.stringify({ apiKey: "...", authDomain: "...", projectId: "..." });
+    window.__app_id = "canvas-prober-12345";
+    window.__initial_auth_token = "placeholder.jwt.token";
+  </script>
+</head>
+<body>
+  <div id="root"></div>
+
+  <!-- 3. Load the self-rendering component. Babel will transpile and execute it. -->
+  <script type="text/babel" src="GeminiAppCanvasCLI.jsx"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a runnable environment for the project's standalone React components.

Key changes include:
- A new `SETUP.md` file that documents the project's CDN-based architecture and configuration requirements.
- A new `index.html` host page that loads React, ReactDOM, and Babel from a CDN and provides a root element for mounting components.
- Refactored `GeminiAppCanvasCLI.jsx` (previously a .txt file) to be a self-rendering component compatible with the browser environment. This involved removing the 'import React' statement and adding rendering logic directly to the file.

This foundational work allows any of the provided components to be run and tested by making similar modifications.